### PR TITLE
Fixed typos and removed old environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,6 @@ review: build
 		-e AWS_ACCESS_KEY_ID \
 		-e AWS_SECRET_ACCESS_KEY \
 		$(DOCKER_GOOGLE_FLAG) \
-		-e SMTP_USER \
-		-e SMTP_PASS \
 		--rm cloudsweeper $${CSP:+--csp=${CSP}} --org-file=$(ORG_FILE) review
 
 mark: build
@@ -47,8 +45,6 @@ warn: build
 		-e AWS_ACCESS_KEY_ID \
 		-e AWS_SECRET_ACCESS_KEY \
 		$(DOCKER_GOOGLE_FLAG) \
-		-e SMTP_USER \
-		-e SMTP_PASS \
 		--rm cloudsweeper $${CSP:+--csp=${CSP}} --warning-hours=$(WARNING_HOURS) --org-file=$(ORG_FILE) warn
 
 untagged: build
@@ -56,8 +52,6 @@ untagged: build
 		-e AWS_ACCESS_KEY_ID \
 		-e AWS_SECRET_ACCESS_KEY \
 		$(DOCKER_GOOGLE_FLAG) \
-		-e SMTP_USER \
-		-e SMTP_PASS \
 		--rm cloudsweeper find-untagged
 
 billing-report: build
@@ -65,8 +59,6 @@ billing-report: build
 		-e AWS_ACCESS_KEY_ID \
 		-e AWS_SECRET_ACCESS_KEY \
 		$(DOCKER_GOOGLE_FLAG) \
-		-e SMTP_USER \
-		-e SMTP_PASS \
 		--rm cloudsweeper $${CSP:+--csp=${CSP}} --org-file=$(ORG_FILE) billing-report
 
 find:

--- a/cmd/cloudsweeper/main.go
+++ b/cmd/cloudsweeper/main.go
@@ -38,8 +38,8 @@ var (
 	billingBucket          = flag.String("billing-bucket", "", "Specify bucket with billing CSVs")
 	awsBillingSortTag      = flag.String("billing-sort-tag", "", "Specify a tag to sort on when creating report")
 
-	mailUser     = flag.String("smpt-username", "", "SMTP username used to send email")
-	mailPassword = flag.String("smpt-password", "", "SMTP password used to send email")
+	mailUser     = flag.String("smtp-username", "", "SMTP username used to send email")
+	mailPassword = flag.String("smtp-password", "", "SMTP password used to send email")
 	mailServer   = flag.String("smtp-server", "", "SMTP server used to send mail")
 	mailPort     = flag.String("smtp-port", "", "SMTP port used to send mail")
 


### PR DESCRIPTION
These typos led to the following error(s) when using the example config:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xdafa76]

goroutine 1 [running]:
main.findConfig(0x11e329c, 0xd, 0xc42055bca8, 0xd0f33f)
        /go/src/github.com/cloudtools/cloudsweeper/cmd/cloudsweeper/config.go:62 +0xa6
main.initNotifyClient(0xc42001e400)
        /go/src/github.com/cloudtools/cloudsweeper/cmd/cloudsweeper/main.go:166 +0x48
main.main()
/go/src/github.com/cloudtools/cloudsweeper/cmd/cloudsweeper/main.go:129 +0x1158
```

With the rename to `smtp`, it now works as expected.

Also removed some old references to environment variables in the Makefile since they are no longer used.