### PR TITLE
Fix broken (commented out) calls and rename confusing flag

### DIFF
--- a/cloudsweeper/notify/notify.go
+++ b/cloudsweeper/notify/notify.go
@@ -232,10 +232,11 @@ func (c *Client) UntaggedResourcesReview(mngr cloud.ResourceManager, accountUser
 
 		if mailData.ResourceCount() > 0 {
 			// Send mail
-			// title := fmt.Sprintf("You have %d un-tagged resources to review (%s)", mailData.ResourceCount(), time.Now().Format("2006-01-02"))
+			title := fmt.Sprintf("You have %d un-tagged resources to review (%s)", mailData.ResourceCount(), time.Now().Format("2006-01-02"))
 			// You can add some debug email address to ensure it works
 			// debugAddressees := []string{"ben@example.com"}
-			// mailData.SendEmail(untaggedMailTemplate, title, debugAddressees...)
+			// mailData.SendEmail(getMailClient(c), c.config.EmailDomain, untaggedMailTemplate, title, debugAddressees...)
+			mailData.SendEmail(getMailClient(c), c.config.EmailDomain, untaggedMailTemplate, title)
 		}
 	}
 }
@@ -266,10 +267,9 @@ func (c *Client) DeletionWarning(hoursInAdvance int, mngr cloud.ResourceManager,
 		}
 
 		if mailData.ResourceCount() > 0 {
-			// Now send email
-			// title := fmt.Sprintf("Deletion warning, %d resources are cleaned up within %d hours", mailData.ResourceCount(), hoursInAdvance)
-			// debugAddressees := []string{"ben@example.com"}
-			// mailData.SendEmail(deletionWarningTemplate, title, debugAddressees...)
+			// Send email
+			title := fmt.Sprintf("Deletion warning, %d resources are cleaned up within %d hours", mailData.ResourceCount(), hoursInAdvance)
+			mailData.SendEmail(getMailClient(c), c.config.EmailDomain, deletionWarningTemplate, title)
 		}
 	}
 }
@@ -289,10 +289,12 @@ func (c *Client) MonthToDateReport(report billing.Report, accountUserMapping map
 	if err != nil {
 		log.Fatalln("Could not generate email:", err)
 	}
-	log.Printf("Sending the Month-to-date report to %s\n", c.config.SummaryAddressee)
+	summaryAddresseeMail := fmt.Sprintf("%s@%s", c.config.SummaryAddressee, c.config.EmailDomain)
+	recipientMail := convertEmailExceptions(summaryAddresseeMail)
+	log.Printf("Sending the Month-to-date report to %s\n", recipientMail)
 	title := fmt.Sprintf("Month-to-date %s billing report", report.CSP)
-	err = mailClient.SendEmail(title, mailContent, c.config.SummaryAddressee)
+	err = mailClient.SendEmail(title, mailContent, recipientMail)
 	if err != nil {
-		log.Printf("Failed to email %s: %s\n", c.config.SummaryAddressee, err)
+		log.Printf("Failed to email %s: %s\n", recipientMail, err)
 	}
 }

--- a/cloudsweeper/notify/notify.go
+++ b/cloudsweeper/notify/notify.go
@@ -35,14 +35,14 @@ type Client struct {
 
 // Config is a configuration for the notify Client
 type Config struct {
-	SMTPUsername     string
-	SMTPPassword     string
-	SMTPServer       string
-	SMTPPort         int
-	DisplayName      string
-	EmailDomain      string
-	SummaryAddressee string
-	TotalSumAddresse string
+	SMTPUsername           string
+	SMTPPassword           string
+	SMTPServer             string
+	SMTPPort               int
+	DisplayName            string
+	EmailDomain            string
+	BillingReportAddressee string
+	TotalSumAddresse       string
 }
 
 // Init will initialize a notify Client with a given Config
@@ -289,8 +289,8 @@ func (c *Client) MonthToDateReport(report billing.Report, accountUserMapping map
 	if err != nil {
 		log.Fatalln("Could not generate email:", err)
 	}
-	summaryAddresseeMail := fmt.Sprintf("%s@%s", c.config.SummaryAddressee, c.config.EmailDomain)
-	recipientMail := convertEmailExceptions(summaryAddresseeMail)
+	billingReportMail := fmt.Sprintf("%s@%s", c.config.BillingReportAddressee, c.config.EmailDomain)
+	recipientMail := convertEmailExceptions(billingReportMail)
 	log.Printf("Sending the Month-to-date report to %s\n", recipientMail)
 	title := fmt.Sprintf("Month-to-date %s billing report", report.CSP)
 	err = mailClient.SendEmail(title, mailContent, recipientMail)

--- a/cmd/cloudsweeper/config.go
+++ b/cmd/cloudsweeper/config.go
@@ -37,11 +37,11 @@ var configMapping = map[string]lookup{
 	"smtp-port":     lookup{"CS_SMTP_PORT", "587"},
 
 	// Notifying specific variables
-	"warning-hours":       lookup{"CS_WARNING_HOURS", "48"},
-	"display-name":        lookup{"CS_DISPLAY_NAME", "Cloudsweeper"},
-	"summary-addressee":   lookup{"CS_SUMMARY_ADDRESSEE", ""},
-	"total-sum-addressee": lookup{"CS_TOTAL_SUM_ADDRESSEE", ""},
-	"mail-domain":         lookup{"CS_EMAIL_DOMAIN", ""},
+	"warning-hours":            lookup{"CS_WARNING_HOURS", "48"},
+	"display-name":             lookup{"CS_DISPLAY_NAME", "Cloudsweeper"},
+	"billing-report-addressee": lookup{"CS_BILLING_REPORT_ADDRESSEE", ""},
+	"total-sum-addressee":      lookup{"CS_TOTAL_SUM_ADDRESSEE", ""},
+	"mail-domain":              lookup{"CS_EMAIL_DOMAIN", ""},
 
 	// Setup variables
 	"aws-master-arn": lookup{"CS_MASTER_ARN", ""},

--- a/cmd/cloudsweeper/main.go
+++ b/cmd/cloudsweeper/main.go
@@ -43,11 +43,11 @@ var (
 	mailServer   = flag.String("smtp-server", "", "SMTP server used to send mail")
 	mailPort     = flag.String("smtp-port", "", "SMTP port used to send mail")
 
-	warningHours    = flag.String("warning-hours", "", "The number of hours in advance to warn about resource deletion")
-	displayName     = flag.String("display-name", "", "Name displayed on emails sent by Cloudsweeper")
-	summaryReciever = flag.String("summary-addressee", "", "Reciever of month to date summaries")
-	summaryManager  = flag.String("total-sum-addressee", "", "Reciever of total cost sums")
-	mailDomain      = flag.String("mail-domain", "", "The mail domain appended to usernames specified in the organization")
+	warningHours          = flag.String("warning-hours", "", "The number of hours in advance to warn about resource deletion")
+	displayName           = flag.String("display-name", "", "Name displayed on emails sent by Cloudsweeper")
+	billingReportReceiver = flag.String("billing-report-addressee", "", "Receiver of month to date billing report")
+	summaryManager        = flag.String("total-sum-addressee", "", "Receiver of total cost sums")
+	mailDomain            = flag.String("mail-domain", "", "The mail domain appended to usernames specified in the organization")
 
 	setupARN = flag.String("aws-master-arn", "", "AWS ARN of role in account used by Cloudsweeper to assume roles")
 
@@ -163,14 +163,14 @@ func initManager(csp cloud.CSP, org *cs.Organization) cloud.ResourceManager {
 
 func initNotifyClient() *notify.Client {
 	config := &notify.Config{
-		SMTPUsername:     findConfig("smtp-username"),
-		SMTPPassword:     findConfig("smtp-password"),
-		SMTPServer:       findConfig("smtp-server"),
-		SMTPPort:         findConfigInt("smtp-port"),
-		DisplayName:      findConfig("display-name"),
-		EmailDomain:      findConfig("mail-domain"),
-		SummaryAddressee: findConfig("summary-addressee"),
-		TotalSumAddresse: findConfig("total-sum-addressee"),
+		SMTPUsername:           findConfig("smtp-username"),
+		SMTPPassword:           findConfig("smtp-password"),
+		SMTPServer:             findConfig("smtp-server"),
+		SMTPPort:               findConfigInt("smtp-port"),
+		DisplayName:            findConfig("display-name"),
+		EmailDomain:            findConfig("mail-domain"),
+		BillingReportAddressee: findConfig("billing-report-addressee"),
+		TotalSumAddresse:       findConfig("total-sum-addressee"),
 	}
 	return notify.Init(config)
 }

--- a/config.conf
+++ b/config.conf
@@ -24,7 +24,7 @@ CS_BILLING_ACCOUNT: foo
 # CS_BILLING_BUCKET_NAME defines the name/id of the bucket where the 
 # billing report file will be located.
 CS_BILLING_BUCKET_NAME: foo
-# CS_BILLING_BUCKET_REGION defines the AWS region where t   he bucket
+# CS_BILLING_BUCKET_REGION defines the AWS region where the bucket
 # specified by CS_BILLING_BUCKET_NAME is located.
 CS_BILLING_BUCKET_REGION: us-west-2
 # CS_BILLING_CSV_PREFIX defines the prefix of the billing report
@@ -39,10 +39,10 @@ CS_BILLING_SORT_TAG:
 # CS_SMTP_USER defines the username used when authenticating with
 # the SMTP server to send mail. If using Gmail, this would be
 # the full email, e.g. example@gmail.com.
-CS_SMTP_USER:
+CS_SMTP_USER: example@gmail.com
 # CS_SMTP_PASSWORD defines the password used when authenticating with
 # the SMTP server to send mail.
-CS_SMTP_PASSWORD:
+CS_SMTP_PASSWORD: password
 # CS_SMTP_SERVER defines the server that will be used for sending
 # email.
 CS_SMTP_SERVER: smtp.gmail.com
@@ -60,16 +60,18 @@ CS_DISPLAY_NAME: Cloudsweeper
 # rest, you add it as an exception in the emailEdgeCases map within
 # "cloudsweeper/notify/helpers.go".
 CS_EMAIL_DOMAIN: example.com
-# CS_SUMMARY_ADDRESSEE defines an email address where summaries should
-# be sent. This could perhaps be a common engineering email that
+# CS_BILLING_REPORT_ADDRESSEE defines an employee/alias where the billing report
+# should be sent. This could perhaps be a common engineering email that
 # all engineers recieve.
-CS_SUMMARY_ADDRESSEE:
-# CS_TOTAL_SUM_ADDRESSEE defines an employee username that should
+# e.g 'engineering' - then the full email address will be engineering@<CS_EMAIL_DOMAIN>
+CS_BILLING_REPORT_ADDRESSEE: engineering
+# CS_TOTAL_SUM_ADDRESSEE defines an employee/alias that should
 # get a total summary of all resources. This person is probably
 # the one responsible for cost management within your company.
-CS_TOTAL_SUM_ADDRESSEE:
+# e.g 'cogs' - then the full email address will be cogs@<CS_EMAIL_DOMAIN>
+CS_TOTAL_SUM_ADDRESSEE: cogs
 
 ########################## Setup configs ##############################
 # CS_MASTER_ARN defines the ARN of the AWS IAM user within an account
 # that is used by the master machine, as descibed in Instructions.md.
-CS_MASTER_ARN:
+CS_MASTER_ARN: arn:aws:iam::123456789123:user/cloudsweeper-master


### PR DESCRIPTION
Fixed two calls to `SendEmail` that previously were commented out and since then have had their function signature changed. 
When the calls where commented out:
`SendEmail(mailTemplate, title string, debugAddressees ...string)`
but now they are:
`SendEmail(client mailer.Client, domain, mailTemplate, title string, debugAddressees ...string)`

So:
`// mailData.SendEmail(deletionWarningTemplate, title)`
becomes:
`mailData.SendEmail(getMailClient(c), c.config.EmailDomain, deletionWarningTemplate, title)`
and so on. Should work now, can build without compilation errors.

Renamed a pretty confusing flag and also made it consistent so that every email alias is only specified as `alias` instead of some being specified as `alias` and some being specified as `alias@domain.com`. It's still possible to override the `domain.com` using an email edge case.