### PR TITLE
Add configurable from email and minor fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+aws_setup.sh
+config.conf
+Dockerfile
+Instructions.md
+LICENSE
+Makefile
+NOTICE
+organization.json
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -465,7 +465,3 @@ __pycache__/
 # should be stored in the .pubxml.user file.
 
 # End of https://www.gitignore.io/api/macos,linux,windows,intellij,sublimetext,visualstudio,visualstudiocode
-
-# artifacts
-aws_accounts.json
-organization.json

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ run: build
 		$(DOCKER_GOOGLE_FLAG) \
 		-v $(shell pwd)/$(ORG_FILE):/$(ORG_FILE) \
 		-v $(shell pwd)/$(CONF_FILE):/$(CONF_FILE) \
-		--rm $(CONTAINER_TAG)  $${CSP:+--csp=${CSP}} --org-file=$(ORG_FILE)
+		--rm $(CONTAINER_TAG)
 
 cleanup: build
 	docker run \
@@ -29,7 +29,7 @@ cleanup: build
 		$(DOCKER_GOOGLE_FLAG) \
 		-v $(shell pwd)/$(ORG_FILE):/$(ORG_FILE) \
 		-v $(shell pwd)/$(CONF_FILE):/$(CONF_FILE) \
-		--rm $(CONTAINER_TAG) $${CSP:+--csp=${CSP}} --org-file=$(ORG_FILE) cleanup
+		--rm $(CONTAINER_TAG) cleanup
 
 reset: build
 	docker run \
@@ -38,7 +38,7 @@ reset: build
 		$(DOCKER_GOOGLE_FLAG) \
 		-v $(shell pwd)/$(ORG_FILE):/$(ORG_FILE) \
 		-v $(shell pwd)/$(CONF_FILE):/$(CONF_FILE) \
-		--rm $(CONTAINER_TAG) $${CSP:+--csp=${CSP}} --org-file=$(ORG_FILE) reset
+		--rm $(CONTAINER_TAG) reset
 
 review: build
 	docker run \
@@ -47,14 +47,14 @@ review: build
 		$(DOCKER_GOOGLE_FLAG) \
 		-v $(shell pwd)/$(ORG_FILE):/$(ORG_FILE) \
 		-v $(shell pwd)/$(CONF_FILE):/$(CONF_FILE) \
-		--rm $(CONTAINER_TAG) $${CSP:+--csp=${CSP}} --org-file=$(ORG_FILE) review
+		--rm $(CONTAINER_TAG) review
 
 mark: build
 	docker run \
 		-e AWS_ACCESS_KEY_ID \
 		-e AWS_SECRET_ACCESS_KEY \
 		$(DOCKER_GOOGLE_FLAG) \
-		--rm $(CONTAINER_TAG) $${CSP:+--csp=${CSP}} --org-file=$(ORG_FILE) mark-for-cleanup
+		--rm $(CONTAINER_TAG) mark-for-cleanup
 
 warn: build
 	docker run \
@@ -63,7 +63,7 @@ warn: build
 		$(DOCKER_GOOGLE_FLAG) \
 		-v $(shell pwd)/$(ORG_FILE):/$(ORG_FILE) \
 		-v $(shell pwd)/$(CONF_FILE):/$(CONF_FILE) \
-		--rm $(CONTAINER_TAG) $${CSP:+--csp=${CSP}} --warning-hours=$(WARNING_HOURS) --org-file=$(ORG_FILE) warn
+		--rm $(CONTAINER_TAG) warn
 
 untagged: build
 	docker run \
@@ -81,7 +81,7 @@ billing-report: build
 		$(DOCKER_GOOGLE_FLAG) \
 		-v $(shell pwd)/$(ORG_FILE):/$(ORG_FILE) \
 		-v $(shell pwd)/$(CONF_FILE):/$(CONF_FILE) \
-		--rm $(CONTAINER_TAG) $${CSP:+--csp=${CSP}} --org-file=$(ORG_FILE) billing-report
+		--rm $(CONTAINER_TAG) billing-report
 
 find: build
 	docker run \
@@ -90,7 +90,7 @@ find: build
 		$(DOCKER_GOOGLE_FLAG) \
 		-v $(shell pwd)/$(ORG_FILE):/$(ORG_FILE) \
 		-v $(shell pwd)/$(CONF_FILE):/$(CONF_FILE) \
-		--rm $(CONTAINER_TAG) $${CSP:+--csp=${CSP}} --org-file=$(ORG_FILE) --resource-id=$(RESOURCE_ID) find-resource
+		--rm $(CONTAINER_TAG) --resource-id=$(RESOURCE_ID) find-resource
 
 setup: build
 	docker run \

--- a/cloudsweeper/notify/helpers.go
+++ b/cloudsweeper/notify/helpers.go
@@ -47,8 +47,9 @@ func getMailClient(notifyClient *Client) mailer.Client {
 	password := notifyClient.config.SMTPPassword
 	server := notifyClient.config.SMTPServer
 	port := notifyClient.config.SMTPPort
+	from := notifyClient.config.MailFrom
 	displayName := notifyClient.config.DisplayName
-	return mailer.NewClient(username, password, displayName, server, port)
+	return mailer.NewClient(username, password, displayName, from, server, port)
 }
 
 func extraTemplateFunctions() template.FuncMap {

--- a/cloudsweeper/notify/notify.go
+++ b/cloudsweeper/notify/notify.go
@@ -40,6 +40,7 @@ type Config struct {
 	SMTPServer             string
 	SMTPPort               int
 	DisplayName            string
+	MailFrom               string
 	EmailDomain            string
 	BillingReportAddressee string
 	TotalSumAddresse       string

--- a/cmd/cloudsweeper/config.go
+++ b/cmd/cloudsweeper/config.go
@@ -39,6 +39,7 @@ var configMapping = map[string]lookup{
 	// Notifying specific variables
 	"warning-hours":            lookup{"CS_WARNING_HOURS", "48"},
 	"display-name":             lookup{"CS_DISPLAY_NAME", "Cloudsweeper"},
+	"mail-from":                lookup{"CS_MAIL_FROM", ""},
 	"billing-report-addressee": lookup{"CS_BILLING_REPORT_ADDRESSEE", ""},
 	"total-sum-addressee":      lookup{"CS_TOTAL_SUM_ADDRESSEE", ""},
 	"mail-domain":              lookup{"CS_EMAIL_DOMAIN", ""},

--- a/cmd/cloudsweeper/main.go
+++ b/cmd/cloudsweeper/main.go
@@ -45,6 +45,7 @@ var (
 
 	warningHours          = flag.String("warning-hours", "", "The number of hours in advance to warn about resource deletion")
 	displayName           = flag.String("display-name", "", "Name displayed on emails sent by Cloudsweeper")
+	mailFrom              = flag.String("mail-from", "", "'From Email' displayed on emails sent by Cloudsweeper")
 	billingReportReceiver = flag.String("billing-report-addressee", "", "Receiver of month to date billing report")
 	summaryManager        = flag.String("total-sum-addressee", "", "Receiver of total cost sums")
 	mailDomain            = flag.String("mail-domain", "", "The mail domain appended to usernames specified in the organization")
@@ -55,11 +56,11 @@ var (
 )
 
 const banner = `
-   ___ _                 _                                       
-  / __\ | ___  _   _  __| |_____      _____  ___ _ __   ___ _ __ 
+   ___ _                 _
+  / __\ | ___  _   _  __| |_____      _____  ___ _ __   ___ _ __
  / /  | |/ _ \| | | |/ _` + "`" + ` / __\ \ /\ / / _ \/ _ \ '_ \ / _ \ '__|
-/ /___| | (_) | |_| | (_| \__ \\ V  V /  __/  __/ |_) |  __/ |   
-\____/|_|\___/ \__,_|\__,_|___/ \_/\_/ \___|\___| .__/ \___|_|   
+/ /___| | (_) | |_| | (_| \__ \\ V  V /  __/  __/ |_) |  __/ |
+\____/|_|\___/ \__,_|\__,_|___/ \_/\_/ \___|\___| .__/ \___|_|
                                                 |_|
 `
 
@@ -168,6 +169,7 @@ func initNotifyClient() *notify.Client {
 		SMTPServer:             findConfig("smtp-server"),
 		SMTPPort:               findConfigInt("smtp-port"),
 		DisplayName:            findConfig("display-name"),
+		MailFrom:               findConfig("mail-from"),
 		EmailDomain:            findConfig("mail-domain"),
 		BillingReportAddressee: findConfig("billing-report-addressee"),
 		TotalSumAddresse:       findConfig("total-sum-addressee"),

--- a/config.conf
+++ b/config.conf
@@ -5,8 +5,8 @@
 ######################### Generic configs #############################
 # CS_CSP defines which CSP to run against. Can be either
 # 'aws' or 'gcp. Can be overridden using the '--csp' flag.
-CS_CSP: aws 
-# CS_ORG_FILE defines the location of the organization 
+CS_CSP: aws
+# CS_ORG_FILE defines the location of the organization
 # definition file. This can be any local path on the machine.
 CS_ORG_FILE: organization.json
 # CS_WARNING_HOURS defines when Cloudsweeper will start warning
@@ -18,10 +18,10 @@ CS_ORG_FILE: organization.json
 CS_WARNING_HOURS: 48
 
 ########################## Billing configs ############################
-# CS_BILLING_ACCOUNT defines the AWS account ID where the 
+# CS_BILLING_ACCOUNT defines the AWS account ID where the
 # billing report CSV is located.
 CS_BILLING_ACCOUNT: foo
-# CS_BILLING_BUCKET_NAME defines the name/id of the bucket where the 
+# CS_BILLING_BUCKET_NAME defines the name/id of the bucket where the
 # billing report file will be located.
 CS_BILLING_BUCKET_NAME: foo
 # CS_BILLING_BUCKET_REGION defines the AWS region where the bucket
@@ -54,6 +54,9 @@ CS_SMTP_PORT: 587
 # CS_DISPLAY_NAME defines the name that will be shown as sender in the
 # mails sent by Cloudsweeper.
 CS_DISPLAY_NAME: Cloudsweeper
+# CS_MAIL_FROM defines the email address that will be shown as sender in the
+# mails sent by Cloudsweeper. This is often the same as CS_SMTP_USER
+CS_MAIL_FROM: example@gmail.com
 # CS_EMAIL_DOMAIN defines the domain used for email in your company. It
 # will be appended to the employee username like "<username>@<domain>".
 # If you have an employee which has a different domain name than the

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -35,17 +35,18 @@ type Client interface {
 type mailer struct {
 	user        string
 	auth        smtp.Auth
+	from        string
 	displayName string
 	smtpServer  string
 	smtpPort    int
 }
 
 // NewClient will create a new email client for sending mails
-func NewClient(username, password, displayName string, smtpServer string, smtpPort int) Client {
+func NewClient(username, password, displayName, from, smtpServer string, smtpPort int) Client {
 	auth := smtp.PlainAuth("", username, password, smtpServer)
 	m := new(mailer)
 	m.auth = auth
-	m.user = username
+	m.from = from
 	m.displayName = displayName
 	m.smtpServer = smtpServer
 	m.smtpPort = smtpPort
@@ -60,7 +61,7 @@ func (m *mailer) SendEmail(subject, content string, recipients ...string) error 
 	var msg bytes.Buffer
 
 	context := &mailContext{
-		From:        m.user,
+		From:        m.from,
 		To:          strings.Join(recipients, ", "),
 		Subject:     subject,
 		Body:        content,
@@ -78,7 +79,7 @@ func (m *mailer) SendEmail(subject, content string, recipients ...string) error 
 		return err
 	}
 
-	err = smtp.SendMail(server, m.auth, m.user, recipients, msg.Bytes())
+	err = smtp.SendMail(server, m.auth, m.from, recipients, msg.Bytes())
 	return err
 }
 

--- a/organization.json
+++ b/organization.json
@@ -20,7 +20,7 @@
 			"disabled": false,
 			"aws_accounts": [
 				{
-					"id": "12345667890",
+					"id": "111111111111",
 					"cloudsweeper_enabled": true
 				}
 			],
@@ -37,7 +37,7 @@
 			"department": "dev",
 			"aws_accounts": [
 				{
-					"id": "09876543234",
+					"id": "999999999999",
 					"cloudsweeper_enabled": false
 				}
 			],


### PR DESCRIPTION
**2 minor changes:**
* Removed some flags in the make targets, for example `--csp` and `--org-file`, since they are set in the config file. Having some flags specified in the `Makefile` while others are not specified only leads to confusion in my opinion.

* Renamed the example `organization.json` file so that it is consistent with the example `config.conf` file.
Also added a `.dockerignore` file so that we never pull in configuration files in the image. This will speed up image build times since making changes to the config files, `Makefile`, `README.md` no longer invalidates the cache.

---
**1 bigger change:**
Introduces a new config field called `CS_MAIL_FROM`.

Some SMTP servers have usernames that are not email addresses. We therefore need to be able to configure a From email. I have not been able to fully test this yet.