### PR TITLE
Speed up bucket parsing and fix a bunch of bugs

### DIFF
--- a/aws_setup.sh
+++ b/aws_setup.sh
@@ -34,7 +34,8 @@ CLOUDSWEEPER_POLICY='{
                 "s3:GetBucketLocation",
                 "s3:PutBucketTagging",
                 "s3:DeleteObject",
-                "s3:DeleteBucket"
+                "s3:DeleteBucket",
+                "cloudwatch:GetMetricStatistics"
             ],
             "Resource": [
                 "*"

--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -228,7 +228,9 @@ func (m *awsResourceManager) BucketsPerAccount() map[string][]Bucket {
 						tags = convertAWSS3Tags(buTags.TagSet)
 					}
 
-					cw := cloudwatch.New(sess, &aws.Config{Region: aws.String(region)})
+					cw := cloudwatch.New(sess, &aws.Config{
+						Credentials: cred,
+						Region:      aws.String(region)})
 					size := 0
 					numberOfObjects := int64(0)
 

--- a/cloud/billing/pricing.go
+++ b/cloud/billing/pricing.go
@@ -40,7 +40,10 @@ var awsRegionNameToIDMap = map[string]string{
 	"EU (Ireland)":               "eu-west-1",
 	"EU (London)":                "eu-west-2",
 	"EU (Paris)":                 "eu-west-3",
+	"EU (Stockholm)":             "eu-north-1",
 	"South America (Sao Paulo)":  "sa-east-1",
+	"AWS GovCloud (US-East)":     "unknown",
+	"AWS GovCloud (US-West)":     "unknown",
 	"AWS GovCloud (US)":          "unknown",
 }
 
@@ -210,7 +213,7 @@ func awsInstancePricePerHour(region, instanceType string) float64 {
 			for _, price := range term.PriceDimensions {
 				regionID, ok := awsRegionNameToIDMap[product.Region]
 				if !ok {
-					log.Fatalln("Got an unknown region from AWS")
+					log.Fatalln("Got an unknown region from AWS:", product.Region)
 				}
 				key := instanceKeyPair{
 					Region:       regionID,

--- a/cloud/billing/pricing.go
+++ b/cloud/billing/pricing.go
@@ -42,9 +42,9 @@ var awsRegionNameToIDMap = map[string]string{
 	"EU (Paris)":                 "eu-west-3",
 	"EU (Stockholm)":             "eu-north-1",
 	"South America (Sao Paulo)":  "sa-east-1",
-	"AWS GovCloud (US-East)":     "unknown",
-	"AWS GovCloud (US-West)":     "unknown",
-	"AWS GovCloud (US)":          "unknown",
+	"AWS GovCloud (US-East)":     "us-gov-east-1",
+	"AWS GovCloud (US-West)":     "us-gov-west-1",
+	"AWS GovCloud (US)":          "us-gov-west-1",
 }
 
 // Storage cost per GB per day

--- a/cloud/filter/filter_test.go
+++ b/cloud/filter/filter_test.go
@@ -103,7 +103,7 @@ func (i *testImg) MakePrivate() error { return nil }
 // This will test the filters being used when marking resources for
 // cleanup. These are:
 // 		- unattached volumes > 30 days old
-//		- unused/unaccessed buckets > 120 days old
+//		- unused/unaccessed buckets > 6 months (182 days)
 // 		- non-whitelisted AMIs > 6 months
 // 		- non-whitelisted snapshots > 6 months
 // 		- non-whitelisted volumes > 6 months
@@ -133,7 +133,7 @@ func TestCleanupRulesFilter(t *testing.T) {
 	unattachedFilter.AddGeneralRule(Negate(TaggedForCleanup()))
 
 	bucketFilter := New()
-	bucketFilter.AddBucketRule(NotModifiedInXDays(120))
+	bucketFilter.AddBucketRule(NotModifiedInXDays(182))
 	bucketFilter.AddGeneralRule(OlderThanXDays(7))
 	bucketFilter.AddGeneralRule(Negate(HasTag("Release")))
 	bucketFilter.AddGeneralRule(Negate(TaggedForCleanup()))

--- a/cloudsweeper/cleanup/cleanup.go
+++ b/cloudsweeper/cleanup/cleanup.go
@@ -22,7 +22,7 @@ const (
 // a tag that will delete the resources 4 days from now. The rules
 // for marking a resource for cleanup are the following:
 // 		- unattached volumes > 30 days old
-//		- unused/unaccessed buckets > 120 days old
+//		- unused/unaccessed buckets > 6 months (182 days)
 // 		- non-whitelisted AMIs > 6 months
 // 		- non-whitelisted snapshots > 6 months
 // 		- non-whitelisted volumes > 6 months
@@ -56,7 +56,7 @@ func MarkForCleanup(mngr cloud.ResourceManager) {
 		unattachedFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))
 
 		bucketFilter := filter.New()
-		bucketFilter.AddBucketRule(filter.NotModifiedInXDays(120))
+		bucketFilter.AddBucketRule(filter.NotModifiedInXDays(182))
 		bucketFilter.AddGeneralRule(filter.OlderThanXDays(7))
 		bucketFilter.AddGeneralRule(filter.Negate(filter.HasTag(releaseTag)))
 		bucketFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))

--- a/cloudsweeper/notify/helpers.go
+++ b/cloudsweeper/notify/helpers.go
@@ -69,6 +69,14 @@ func extraTemplateFunctions() template.FuncMap {
 				return fmt.Sprintf("%d days ago", days)
 			}
 		},
+		// TODO: this should be configurable
+		"modifiedInTheLast6Months": func(t time.Time) string {
+			if time.Now().Before(t.AddDate(0, 6, 0)) {
+				return "true"
+			}
+			return "false"
+		},
+
 		"even": func(num int) bool { return num%2 == 0 },
 		"yesno": func(b bool) string {
 			if b {

--- a/cloudsweeper/notify/templates.go
+++ b/cloudsweeper/notify/templates.go
@@ -31,7 +31,7 @@ whitelist it: add a tag with the key "cloudsweeper-whitelisted" to it.
 </p>
 
 <p>
-To schedule automated clean up, please add one of the following two types of tags (key: value) to your resource: 
+To schedule automated clean up, please add one of the following two types of tags (key: value) to your resource:
 <br />
 "<b>cloudsweeper-lifetime</b>: days-x", where x is the amount of days to keep the resource
 <br />
@@ -157,7 +157,7 @@ Resources marked <span style="background-color: #c9fc99;">in green</span> are wh
 			<th><strong>ID</strong></th>
 			<th><strong>Size (GB)</strong></th>
 			<th><strong>Files</strong></th>
-			<th><strong>Last modified</strong></th>
+			<th><strong>Modified in < 6 months</strong></th>
 			<th><strong>Monthly cost</strong></th>
 		</tr>
 	{{ range $i, $bucket := .Buckets }}
@@ -166,7 +166,7 @@ Resources marked <span style="background-color: #c9fc99;">in green</span> are wh
 			<td>{{ $bucket.ID }}</td>
 			<td>{{ printf "%.3f GB" $bucket.TotalSizeGB }}</td>
 			<td>{{ $bucket.ObjectCount }}</td>
-			<td>{{ fdate $bucket.LastModified "2006-01-02" }} ({{ daysrunning $bucket.LastModified }})</td>
+			<td>{{ modifiedInTheLast6Months $bucket.LastModified }}</td>
 			<td>{{ printf "$%.3f" (bucketcost $bucket) }}</td>
 		</tr>
 	{{ end }}
@@ -299,7 +299,7 @@ Resources marked <span style="background-color: #c9fc99;">in green</span> are wh
 			<th><strong>ID</strong></th>
 			<th><strong>Size (GB)</strong></th>
 			<th><strong>Files</strong></th>
-			<th><strong>Last modified</strong></th>
+			<th><strong>Modified in < 6 months</strong></th>
 			<th><strong>Monthly cost</strong></th>
 		</tr>
 	{{ range $i, $bucket := .Buckets }}
@@ -308,7 +308,7 @@ Resources marked <span style="background-color: #c9fc99;">in green</span> are wh
 			<td>{{ $bucket.ID }}</td>
 			<td>{{ printf "%.3f GB" $bucket.TotalSizeGB }}</td>
 			<td>{{ $bucket.ObjectCount }}</td>
-			<td>{{ fdate $bucket.LastModified "2006-01-02" }} ({{ daysrunning $bucket.LastModified }})</td>
+			<td>{{ modifiedInTheLast6Months $bucket.LastModified }}</td>
 			<td>{{ printf "$%.3f" (bucketcost $bucket) }}</td>
 		</tr>
 	{{ end }}
@@ -441,7 +441,7 @@ Resources marked <span style="background-color: #c9fc99;">in green</span> are wh
 			<th><strong>ID</strong></th>
 			<th><strong>Size (GB)</strong></th>
 			<th><strong>Files</strong></th>
-			<th><strong>Last modified</strong></th>
+			<th><strong>Modified in < 6 months</strong></th>
 			<th><strong>Monthly cost</strong></th>
 		</tr>
 	{{ range $i, $bucket := .Buckets }}
@@ -450,7 +450,7 @@ Resources marked <span style="background-color: #c9fc99;">in green</span> are wh
 			<td>{{ $bucket.ID }}</td>
 			<td>{{ printf "%.3f GB" $bucket.TotalSizeGB }}</td>
 			<td>{{ $bucket.ObjectCount }}</td>
-			<td>{{ fdate $bucket.LastModified "2006-01-02" }} ({{ daysrunning $bucket.LastModified }})</td>
+			<td>{{ modifiedInTheLast6Months $bucket.LastModified }}</td>
 			<td>{{ printf "$%.3f" (bucketcost $bucket) }}</td>
 		</tr>
 	{{ end }}
@@ -467,7 +467,7 @@ const deletionWarningTemplate = `<h1>Hello {{ .Owner -}},</h1>
 
 <h2>Resources will be cleaned up within {{ .HoursInAdvance }} hours</h2>
 <p>
-Unless you take action, the resources listed below will be cleaned up 
+Unless you take action, the resources listed below will be cleaned up
 from your account within the next {{ .HoursInAdvance }} hours. <b>Make sure
 you don't need to keep any of these resources</b>
 </p>
@@ -592,7 +592,7 @@ Read more about how Cloudsweeper works and how to better tag your resources at
 			<th><strong>ID</strong></th>
 			<th><strong>Size (GB)</strong></th>
 			<th><strong>Files</strong></th>
-			<th><strong>Last modified</strong></th>
+			<th><strong>Modified in < 6 months</strong></th>
 			<th><strong>Monthly cost</strong></th>
 		</tr>
 	{{ range $i, $bucket := .Buckets }}
@@ -601,7 +601,7 @@ Read more about how Cloudsweeper works and how to better tag your resources at
 			<td>{{ $bucket.ID }}</td>
 			<td>{{ printf "%.3f GB" $bucket.TotalSizeGB }}</td>
 			<td>{{ $bucket.ObjectCount }}</td>
-			<td>{{ fdate $bucket.LastModified "2006-01-02" }} ({{ daysrunning $bucket.LastModified }})</td>
+			<td>{{ modifiedInTheLast6Months $bucket.LastModified }}</td>
 			<td>{{ printf "$%.3f" (bucketcost $bucket) }}</td>
 		</tr>
 	{{ end }}

--- a/cloudsweeper/setup/aws.go
+++ b/cloudsweeper/setup/aws.go
@@ -55,7 +55,7 @@ const (
 
 var (
 	monitorEC2 = []string{"ec2:DescribeInstances", "ec2:DescribeInstanceAttribute", "ec2:DescribeSnapshots", "ec2:DescribeVolumeStatus", "ec2:DescribeVolumes", "ec2:DescribeInstanceStatus", "ec2:DescribeTags", "ec2:DescribeVolumeAttribute", "ec2:DescribeImages", "ec2:DescribeSnapshotAttribute"}
-	monitorS3  = []string{"s3:GetBucketTagging", "s3:ListBucket", "s3:GetObject", "s3:ListAllMyBuckets", "s3:GetBucketLocation"}
+	monitorS3  = []string{"s3:GetBucketTagging", "s3:ListBucket", "s3:GetObject", "s3:ListAllMyBuckets", "s3:GetBucketLocation", "cloudwatch:GetMetricStatistics"}
 
 	cleanupEC2 = []string{"ec2:DeregisterImage", "ec2:DeleteSnapshot", "ec2:DeleteTags", "ec2:ModifyImageAttribute", "ec2:DeleteVolume", "ec2:TerminateInstances", "ec2:CreateTags", "ec2:StopInstances"}
 	cleanupS3  = []string{"s3:PutBucketTagging", "s3:DeleteObject", "s3:DeleteBucket"}


### PR DESCRIPTION
When this tool was ran on an account with a large number of S3 buckets and/or large number of S3 objects, it  used to take a very long time. This is due to the fact that S3 does not provide any properties like object count, total size or a last modified date and thus this tool had to go down each bucket and look at every single object. See https://github.com/aws/aws-cli/issues/1104 for some details

With this change, the object count and total size of the bucket is collected in a matter of seconds using metrics from Cloudwatch. To allow this, new permissions has been added in the various setup methods. Unfortunately, the last modified property can not be retrieved using this method.  But because we no longer need to look at every single object to determine the size and object count of each bucket, we can in practice save a lot of time by limiting the resolution of our time stamp to just: was this bucket modified in the last 6 months or not?

From what used to take hours before I cancelled the run (never finished) - the same operation now takes less than 15 minutes.

Future (planned) improvements include:
* Allow the threshold to be modified - right now it's hard coded to 6 months.
* Allow the user to choose method - if the accounts in the org do not use S3 a lot, you might be able to use the old method (which has an exact last modified date).

Other fixes:
* Fixed a crash due to new regions added in AWS 
* Fixed a crash when encountering a bucket name that is not XML compatible