### PR TITLE
Cleanup function for keeping X latest components

### DIFF
--- a/cloudsweeper/cleanup/cleanup.go
+++ b/cloudsweeper/cleanup/cleanup.go
@@ -4,7 +4,11 @@
 package cleanup
 
 import (
+	"errors"
+	"fmt"
 	"log"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/cloudtools/cloudsweeper/cloud"
@@ -117,6 +121,94 @@ func MarkForCleanup(mngr cloud.ResourceManager, thresholds map[string]int) {
 		} else {
 			log.Printf("%s: Skipping the tagging of resources, total cost $%.2f is less than $%.2f", owner, totalCost, totalCostThreshold)
 		}
+	}
+}
+
+// MarkAllButTwoLatestComponents will look at AMIs, and mark all but the two latest for each
+// component, where the naming of the AMIs is on the form:
+//		"<component name>-<creation timestamp>"
+func MarkAllButTwoLatestComponents(mngr cloud.ResourceManager, thresholds map[string]int) {
+	componentsToKeep := 2 // TODO: Add this to some config somewhere
+	allResources := mngr.AllResourcesPerAccount()
+	for owner, res := range allResources {
+		log.Println("Marking all but the two latest of each component", owner)
+
+		timeToDelete := time.Now().AddDate(0, 0, 4)
+		resourcesToTag := []cloud.Resource{}
+		componentDatesMap := map[string][]time.Time{}
+
+		splitNameAndTime := func(ami cloud.Image) (name string, creationTime time.Time, err error) {
+			nameParts := strings.Split(ami.Name(), "-")
+			if len(nameParts) < 2 {
+				log.Printf("AMI %s doesn't follow the <component>-<time> format", ami.ID())
+				return "", time.Time{}, errors.New("AMI doesn't follow the correct format")
+			}
+			rawDate := nameParts[len(nameParts)-1]
+			componentName := strings.Join(nameParts[:len(nameParts)-1], "-")
+			if parsedDate, err := time.Parse("somelayout", rawDate); err != nil { // TODO: Time layout
+				return componentName, parsedDate, nil
+			} else {
+				log.Printf("Could not parse time \"%s\" of AMI %s", rawDate, ami.ID())
+				return "", time.Time{}, errors.New("could not parse creation time of AMI")
+			}
+		}
+
+		for _, ami := range res.Images {
+			componentName, creationDate, err := splitNameAndTime(ami)
+			if err != nil {
+				fmt.Printf("Got error for AMI %s: %v", ami.ID(), err)
+				// TODO: Might wanna error out here
+				continue
+			}
+			if _, found := componentDatesMap[componentName]; !found {
+				componentDatesMap[componentName] = []time.Time{}
+			}
+			componentDatesMap[componentName] = append(componentDatesMap[componentName], creationDate)
+		}
+
+		findThreshold := func(componentName string) time.Time {
+			times, found := componentDatesMap[componentName]
+			if !found {
+				fmt.Printf("Times not found for some reason")
+				// TODO: Here you most likely wanna error out, this isn't right
+				return time.Now().AddDate(-10, 0, 0)
+			}
+			if componentsToKeep > len(times) {
+				componentsToKeep = len(times)
+			}
+
+			sort.Slice(times, func(i, j int) bool {
+				// Sort times so that newest are first
+				return times[i].After(times[j])
+			})
+
+			threshold := times[componentsToKeep-1]
+			return threshold
+		}
+
+		for _, ami := range res.Images {
+			componentName, creationDate, err := splitNameAndTime(ami)
+			if err != nil {
+				fmt.Printf("Got error for AMI %s: %v", ami.ID(), err)
+				// TODO: Might wanna error out here
+				continue
+			}
+			threshold := findThreshold(componentName)
+			if creationDate.Before(threshold) {
+				// This AMI is too old, mark it
+				resourcesToTag = append(resourcesToTag, ami)
+			}
+		}
+
+		for _, res := range resourcesToTag {
+			err := res.SetTag(filter.DeleteTagKey, timeToDelete.Format(time.RFC3339), true)
+			if err != nil {
+				log.Printf("%s: Failed to tag %s for deletion: %s\n", owner, res.ID(), err)
+			} else {
+				log.Printf("%s: Marked %s for deletion at %s\n", owner, res.ID(), timeToDelete)
+			}
+		}
+
 	}
 }
 


### PR DESCRIPTION
This is a rough implementation of a new clenaup function which will
look at AMIs with the name structure <component>-<creation timestamp>
and only keep the X newest for each component.

Since this is a rough implementation, it might still need some
modifications to fit your needs better, but should definetly work.
It just needs to be added under the "mark-for-cleanup" case in the
main cloudsweeper package.

**NOTE**: This is safe to merge, as it isn't added to run, but you will probably want to develop this further to fit your needs. In particular, take a look at the `// TODO: Time layout`, as you will need to add a parsing layout that follows what you actually use in your AWS account.